### PR TITLE
add basic support for transaction lifecycle hooks

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,9 +1,11 @@
 import { createNamespace, getNamespace, Namespace } from 'cls-hooked'
+import { EventEmitter } from 'events'
 import { EntityManager } from 'typeorm'
 
 export const NAMESPACE_NAME = '__typeOrm___cls_hooked_tx_namespace'
 
 const TYPE_ORM_KEY_PREFIX = '__typeOrm__transactionalEntityManager_'
+const TYPE_ORM_HOOK_KEY = '__typeOrm__transactionalCommitHooks'
 
 export const initializeTransactionalContext = () =>
   getNamespace(NAMESPACE_NAME) || createNamespace(NAMESPACE_NAME)
@@ -20,3 +22,16 @@ export const setEntityManagerForConnection = (
   context: Namespace,
   entityManager: EntityManager | null
 ) => context.set(`${TYPE_ORM_KEY_PREFIX}${connectionName}`, entityManager)
+
+export const getHookInContext = (
+  context: Namespace
+): EventEmitter | null => {
+  return context.get(TYPE_ORM_HOOK_KEY)
+}
+
+export const setHookInContext = (
+  context: Namespace,
+  emitter: EventEmitter | null
+) => {
+  return context.set(TYPE_ORM_HOOK_KEY, emitter)
+}

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,0 +1,57 @@
+import { getNamespace, Namespace } from 'cls-hooked'
+import { EventEmitter } from 'events'
+import { getHookInContext, NAMESPACE_NAME, setHookInContext } from './common'
+
+export const getTransactionalContextHook = () => {
+  const ctx = getNamespace(NAMESPACE_NAME)
+  const emitter = getHookInContext(ctx)
+  if (!emitter) {
+    throw new Error('No hook manager found in context. Are you using @Transactional()?')
+  }
+  return emitter
+}
+
+export const createEmitterInNewContext = (context: Namespace) => context.runAndReturn((_subctx) => {
+  const emitter = new EventEmitter()
+  context.bindEmitter(emitter)
+  return emitter
+})
+
+export const runAndTriggerHooks = async (hook: EventEmitter, cb: () => any) => {
+  try {
+    const res = await cb()
+    setImmediate(() => {
+      hook.emit('commit')
+      hook.emit('end', undefined)
+      hook.removeAllListeners()
+    })
+    return res
+  } catch (err) {
+    setImmediate(() => {
+      hook.emit('rollback', err)
+      hook.emit('end', err)
+      hook.removeAllListeners()
+    })
+    throw err
+  }
+}
+
+export const runInNewHookContext = async (context: Namespace, cb: () => any) => {
+  const hook = createEmitterInNewContext(context)
+  return await context.runAndReturn(() => {
+    setHookInContext(context, hook)
+    return runAndTriggerHooks(hook, cb)
+  })
+}
+
+export const runOnTransactionCommit = (cb: () => void) => {
+  getTransactionalContextHook().once('commit', cb)
+}
+
+export const runOnTransactionRollback = (cb: (e: Error) => void) => {
+  getTransactionalContextHook().once('rollback', cb)
+}
+
+export const runOnTransactionComplete = (cb: (e: Error | undefined) => void) => {
+  getTransactionalContextHook().once('end', cb)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 
 export { BaseRepository } from './BaseRepository'
 export { initializeTransactionalContext } from './common'
+export { runOnTransactionCommit, runOnTransactionComplete, runOnTransactionRollback } from './hook'
 export { Propagation } from './Propagation'
 export { IsolationLevel } from './IsolationLevel'
 export { Transactional } from './Transactional'


### PR DESCRIPTION
`BaseRepository` exposes a `transaction` getter property that returns a promise that is resolved or rejected based on the success or failure of the current transactional context.

Because you hand over control of the transaction creation to this library, there is no way for you to know whether or not the current transaction was sucessfully persisted to the database. The `transaction` promise allows you to work around that.

```typescript
export class PostService {
    constructor(readonly repository: PostRepsitory, readonly events EventService)

        @Transactional()
        async createPost(id, message): Promise<Post> {
            const post = this.repository.create({ id, message })
            const result = await this.repository.save(post)
            this.transaction.then(() => this.events.emit('post created'))
            return result;
        }
}
```

- *DO NOT* await the transaction promise inside your transactional method as it will create a deadlock
- *DO NOT* throw inside your handlers, as it will result in `UnhandledPromiseRejectionWarning`