### PR TITLE
Export getEntityManagerOrTransactionManager for usage in custom repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ import { BaseRepository } from 'typeorm-transactional-cls-hooked';
 export class PostRepository extends BaseRepository<Post> {}
 ```
 
+The only purpose of the `BaseRepository` class is to make sure the `manager` property of the repository will always be the right one. In cases inheritance is not possible, you can always use the same code from `BaseRepository` within your own repository code.
+
+```typescript
+import { getEntityManagerOrTransactionManager } from 'typeorm-transactional-cls-hooked';
+
+class MyRepository<Entity extends ObjectLiteral> extends Repository<Entity> {
+  private _connectionName: string = 'default'
+  private _manager: EntityManager | undefined
+
+  set manager(manager: EntityManager) {
+    this._manager = manager
+    this._connectionName = manager.connection.name
+  }
+
+  // Always get the entityManager from the cls namespace if active, otherwise, use the original or getManager(connectionName)
+  get manager(): EntityManager {
+    return getEntityManagerOrTransactionManager(this._connectionName, this._manager)
+  }
+}
+```
+
+
+
 ## Using Transactional Decorator
 
 - Every service method that needs to be transactional, need to use the `@Transactional()` decorator

--- a/src/BaseRepository.ts
+++ b/src/BaseRepository.ts
@@ -1,10 +1,7 @@
-import { getNamespace } from 'cls-hooked'
-import { EntityManager, getManager, ObjectLiteral, Repository } from 'typeorm'
-import { getEntityManagerForConnection, NAMESPACE_NAME } from './common'
+import { EntityManager, ObjectLiteral, Repository } from 'typeorm'
+import { getEntityManagerOrTransactionManager } from './common'
 
-export class BaseRepository<Entity extends ObjectLiteral> extends Repository<
-  Entity
-> {
+export class BaseRepository<Entity extends ObjectLiteral> extends Repository<Entity> {
   private _connectionName: string = 'default'
   private _manager: EntityManager | undefined
 
@@ -14,22 +11,6 @@ export class BaseRepository<Entity extends ObjectLiteral> extends Repository<
   }
 
   get manager(): EntityManager {
-    return this.getManagerOrTransactionManager()
-  }
-
-  private getManagerOrTransactionManager(): EntityManager {
-    const context = getNamespace(NAMESPACE_NAME)
-
-    if (context && context.active) {
-      const transactionalEntityManager = getEntityManagerForConnection(
-        this._connectionName,
-        context
-      )
-
-      if (transactionalEntityManager) {
-        return transactionalEntityManager
-      }
-    }
-    return this._manager || getManager(this._connectionName)
+    return getEntityManagerOrTransactionManager(this._connectionName, this._manager)
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,6 @@
 import { createNamespace, getNamespace, Namespace } from 'cls-hooked'
 import { EventEmitter } from 'events'
-import { EntityManager } from 'typeorm'
+import { EntityManager, getManager } from 'typeorm'
 
 export const NAMESPACE_NAME = '__typeOrm___cls_hooked_tx_namespace'
 
@@ -9,6 +9,22 @@ const TYPE_ORM_HOOK_KEY = '__typeOrm__transactionalCommitHooks'
 
 export const initializeTransactionalContext = () =>
   getNamespace(NAMESPACE_NAME) || createNamespace(NAMESPACE_NAME)
+
+export const getEntityManagerOrTransactionManager = (
+  connectionName: string,
+  entityManager: EntityManager | undefined
+): EntityManager => {
+  const context = getNamespace(NAMESPACE_NAME)
+
+  if (context && context.active) {
+    const transactionalEntityManager = getEntityManagerForConnection(connectionName, context)
+
+    if (transactionalEntityManager) {
+      return transactionalEntityManager
+    }
+  }
+  return entityManager || getManager(connectionName)
+}
 
 export const getEntityManagerForConnection = (
   connectionName: string,
@@ -23,15 +39,10 @@ export const setEntityManagerForConnection = (
   entityManager: EntityManager | null
 ) => context.set(`${TYPE_ORM_KEY_PREFIX}${connectionName}`, entityManager)
 
-export const getHookInContext = (
-  context: Namespace
-): EventEmitter | null => {
+export const getHookInContext = (context: Namespace): EventEmitter | null => {
   return context.get(TYPE_ORM_HOOK_KEY)
 }
 
-export const setHookInContext = (
-  context: Namespace,
-  emitter: EventEmitter | null
-) => {
+export const setHookInContext = (context: Namespace, emitter: EventEmitter | null) => {
   return context.set(TYPE_ORM_HOOK_KEY, emitter)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { BaseRepository } from './BaseRepository'
-export { initializeTransactionalContext } from './common'
+export { initializeTransactionalContext, getEntityManagerOrTransactionManager } from './common'
 export { runOnTransactionCommit, runOnTransactionComplete, runOnTransactionRollback } from './hook'
 export { Propagation } from './Propagation'
 export { IsolationLevel } from './IsolationLevel'


### PR DESCRIPTION
Simplified the the BaseRepository, so people can copy/paste the code when inheritance is not an option.
exported a special function `getEntityManagerOrTransactionManager` that gets connectionName and original manager, and tries to return the cls scoped entityManager. If the context is not active, will return the original entityManager or will use typeorm `getManager` function