### PR TITLE
Preserve method name on @Transactional method overwrite

### DIFF
--- a/src/Transactional.ts
+++ b/src/Transactional.ts
@@ -102,6 +102,11 @@ export function Transactional(options?: {
         return runWithNewTransaction()
       })
     }
+
+    Reflect.getMetadataKeys(originalMethod).forEach((previousMetadataKey) => {
+      const previousMetadata = Reflect.getMetadata(previousMetadataKey, originalMethod);
+      Reflect.defineMetadata(previousMetadataKey, previousMetadata, descriptor.value);
+    });
     
     Object.defineProperty(descriptor.value, 'name', {value: originalMethod.name, writable: false});
   }

--- a/src/Transactional.ts
+++ b/src/Transactional.ts
@@ -102,5 +102,7 @@ export function Transactional(options?: {
         return runWithNewTransaction()
       })
     }
+    
+    Object.defineProperty(descriptor.value, 'name', {value: originalMethod.name, writable: false});
   }
 }


### PR DESCRIPTION
While using @Transactional that overwriting controller method, preserve the method name for being used later by the @nestjs/swagger for exploring @Body(), @Param(), and @Query() metadata