### PR TITLE
feat: allow use of scoped containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,14 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
+    "typedi": "^0.8.0",
     "typedoc": "^0.12.0",
     "typeorm": "^0.2.8",
     "typescript": "^3.0.3"
   },
   "peerDependencies": {
     "reflect-metadata": ">= 0.1.12",
+    "typedi": ">=0.8.0",
     "typeorm": ">= 0.2.8"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "experimentalDecorators": true,
     "target": "es5",
     "sourceMap": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test/**/*.ts", "dist", "temp"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,11 @@ tsutils@^2.27.2:
   dependencies:
     tslib "^1.8.1"
 
+typedi@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/typedi/-/typedi-0.8.0.tgz#d8e203bd1d41a96e2b0a5c6295147d74b2b2d03e"
+  integrity sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA==
+
 typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"


### PR DESCRIPTION
Hi,

By default, TypeORM only supports a global container[0], which is referenced whenever you call `getManager()`. In this PR you'll see my hacked together a solution using [typedi](https://github.com/typestack/typed), but it requires your service to have a public `container` property exposed so the `@Transactional` decorator can access it.

Is there a better way of doing this? Would it be something you'd be interested in merging? Please let me know your thoughts -- I'm sure there must be a cleaner way of achieving this!

Thanks!

[0] https://github.com/typeorm/typeorm/blob/master/src/container.ts

