### PR TITLE
Move @types/cls-hooked to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "@types/cls-hooked": "^4.2.1",
     "cls-hooked": "^4.2.2"
   },
   "devDependencies": {
-    "@types/cls-hooked": "^4.2.1",
     "@types/jest": "^23.3.2",
     "prettier": "^1.14.3",
     "reflect-metadata": "^0.1.12",


### PR DESCRIPTION
Since there are some types from `@types/cls-hooked` that are [re-exported](https://github.com/odavid/typeorm-transactional-cls-hooked/blob/8713f687e5fdecc66227e0b67b13414a76a49d25/src/hook.ts#L14) by this package, `@types/cls-hooked` must be in `dependencies` rather than `devDependencies`. See [this discussion](https://stackoverflow.com/a/46011417/749644) for more info.