### PR TITLE
Using patchRepositoryManager instead of overriding the manager() 

### DIFF
--- a/src/BaseRepository.ts
+++ b/src/BaseRepository.ts
@@ -1,17 +1,7 @@
-// @ts-nocheck
-import { EntityManager, ObjectLiteral, Repository } from 'typeorm'
-import { getEntityManagerOrTransactionManager } from './common'
+import { ObjectLiteral, Repository } from 'typeorm'
+import { patchRepositoryManager } from './patch-typeorm-repository'
 
 export class BaseRepository<Entity extends ObjectLiteral> extends Repository<Entity> {
-  private _connectionName: string = 'default'
-  private _manager: EntityManager | undefined
-
-  set manager(manager: EntityManager) {
-    this._manager = manager
-    this._connectionName = manager.connection.name
-  }
-
-  get manager(): EntityManager {
-    return getEntityManagerOrTransactionManager(this._connectionName, this._manager)
-  }
 }
+
+patchRepositoryManager(BaseRepository.prototype)

--- a/src/BaseTreeRepository.ts
+++ b/src/BaseTreeRepository.ts
@@ -1,17 +1,7 @@
-// @ts-nocheck
-import { EntityManager, ObjectLiteral, TreeRepository } from 'typeorm'
-import { getEntityManagerOrTransactionManager } from './common'
+import { ObjectLiteral, TreeRepository } from 'typeorm'
+import { patchRepositoryManager } from './patch-typeorm-repository'
 
 export class BaseTreeRepository<Entity extends ObjectLiteral> extends TreeRepository<Entity> {
-  private _connectionName: string = 'default'
-  private _manager: EntityManager | undefined
-
-  set manager(manager: EntityManager) {
-    this._manager = manager
-    this._connectionName = manager.connection.name
-  }
-
-  get manager(): EntityManager {
-    return getEntityManagerOrTransactionManager(this._connectionName, this._manager)
-  }
 }
+
+patchRepositoryManager(BaseTreeRepository.prototype)

--- a/src/Transactional.ts
+++ b/src/Transactional.ts
@@ -24,7 +24,6 @@ export function Transactional(options?: {
 
   return (target: any, methodName: string | symbol, descriptor: TypedPropertyDescriptor<any>) => {
     const originalMethod = descriptor.value
-
     descriptor.value = function(...args: any[]) {
       const context = getNamespace(NAMESPACE_NAME)
       if (!context) {


### PR DESCRIPTION
Regression since 0.1.13
Since typescript > 3.7, types are generated with setter and getters. This causes issues with generation of `BaseRepository.d.ts` and `BaseTreeRepository.d.ts`, and therefore caused compilation issues for consumers.

This should fix #63 and #64 
A new version will be released soon