### PR TITLE
Add unit test mocking information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ export class PostService {
 ```
 
 ## Unit Test Mocking
-`@Transactional` and `BaseRepository` can be mocked to prevent running any of this library code in unit tests.
+`@Transactional` and `BaseRepository` can be mocked to prevent running any of the transactional code in unit tests.
 
 This can be accomplished in Jest with:
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ export class PostService {
 }
 ```
 
+## Unit Test Mocking
+`@Transactional` and `BaseRepository` can be mocked to prevent running any of this library code in unit tests.
+
+This can be accomplished in Jest with:
+
+```typescript
+jest.mock('typeorm-transactional-cls-hooked', () => ({
+  Transactional: () => () => ({}),
+  BaseRepository: class {},
+}));
+```
+
+Repositories, services, etc. can be mocked as usual.
+
 ## Logging / Debug
 The `Transactional` uses the [Typeorm Connection logger](https://github.com/typeorm/typeorm/blob/master/docs/logging.md) to emit [`log` messages](https://github.com/typeorm/typeorm/blob/master/docs/logging.md#logging-options).
 


### PR DESCRIPTION
First off thanks a lot for this package! I was frustrated with the way transactions work in typeorm having to pass an EntityManager around so this is super helpful 😄 

This PR adds unit testing info and a mock for Jest (found in #2). Figured this would be useful for anyone else trying to run `@Transactional` functions in unit tests that don't touch the database. 